### PR TITLE
correct networks used by kibana and version of elasticsearch

### DIFF
--- a/part-1/2.3-在Docker容器中运行Elasticsearch,Kibana和Cerebro/docker-es-7.3/docker-compose.yml
+++ b/part-1/2.3-在Docker容器中运行Elasticsearch,Kibana和Cerebro/docker-es-7.3/docker-compose.yml
@@ -11,9 +11,9 @@ services:
     ports:
       - "5601:5601"
     networks:
-      - es7net
+      - es73net
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.1.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.3.0
     container_name: es73
     environment:
       - cluster.name=geektime


### PR DESCRIPTION
1. networks name used by kibana should by es73net
2. version of elasticsearch 7.1.0 is not compatible with kibana 7.3.0, change to 7.3.0